### PR TITLE
Fix parseLines not parsing numbers correctly

### DIFF
--- a/sys/lib/tsv.ms
+++ b/sys/lib/tsv.ms
@@ -36,8 +36,8 @@ parseLines = function(lines)
 		result[fields[0]] = rowMap
 		for col in range(1, fields.len-1)
 			value = fields[col]
-			if value == "0" or val(value) > 0 then value = val(value)
-			rowMap[colNames[col]] = fields[col]
+			if value == "0" or val(value) != 0 then value = val(value)
+			rowMap[colNames[col]] = value
 		end for
 	end for
 	return result


### PR DESCRIPTION
"val(value) > 0" ignores negative numbers, "val(value) != 0" takes them into account.
"value" was set but not used.

This fixes some unit tests failing.