### PR TITLE
Fix tab-closing logic in fatbits

### DIFF
--- a/sys/demo/fatbits.ms
+++ b/sys/demo/fatbits.ms
@@ -1083,12 +1083,14 @@ layoutTabs = function()
 		t.targetX = x
 		t.tabX = t.targetX
 		if not t.tabWidth then t.tabWidth = t.tabTitle.len * 9 + 50
-		if t.closeBtn == null and t.tabTitle != "+" then
-			t.closeBtn = new CloseButton
-			t.closeBtn.x = x + 20
-			spriteDisp.sprites.push t.closeBtn
+		if t.tabTitle != "+" then
+			if t.closeBtn == null then
+				t.closeBtn = new CloseButton
+				spriteDisp.sprites.push t.closeBtn
+			end if
 			t.closeBtn.update
-		end if
+			t.closeBtn.x = x + 20	
+		end if		
 		x = x + t.tabWidth - 12
 	end for
 end function

--- a/sys/demo/fatbits.ms
+++ b/sys/demo/fatbits.ms
@@ -975,7 +975,7 @@ CloseButton.image = closeBtnClean
 CloseButton.y = 640 - 12
 CloseButton.x = 20
 CloseButton.update = function(dirty, curTab, pressed)
-	if self.localBounds == null then self.addBounds
+	if self.localBounds == null then self.addBounds; yield
 	if dirty then
 		self.image = closeBtnDirty
 		if curTab then tint = "FF" else tint = "AA"

--- a/sys/demo/fatbits.ms
+++ b/sys/demo/fatbits.ms
@@ -1047,7 +1047,7 @@ OpenFile.close = function()
 	idx = tabs.indexOf(self)
 	tabs.remove self
 	globals.selectedTab = tabs[idx-1]
-	layoutTabs; drawTab
+	layoutTabs; drawTabs
 end function
 OpenFile.confirmAndClose = function()
 	dlog = textUtil.Dialog.make("Save changes to " + self.tabTitle + "?",

--- a/sys/demo/fatbits.ms
+++ b/sys/demo/fatbits.ms
@@ -1044,10 +1044,20 @@ OpenFile.saveToDisk = function()
 	end if
 end function
 OpenFile.close = function()
-	idx = tabs.indexOf(self)
-	tabs.remove self
-	globals.selectedTab = tabs[idx-1]
+	tabIdx = tabs.indexOf(self)
+	// Choose the tab before it, or the first one if none left
+	if tabIdx == 0 then newIdx = 0 else newIdx = tabIdx - 1
+	// Remove the close button of the removed tab
+	sprIdx = spriteDisp.sprites.indexOf(self.closeBtn)
+	spriteDisp.sprites.remove sprIdx
+	// Remove the tab object
+	tabs.remove tabIdx
+	// Point to new tab
+	newTab = tabs[newIdx]
+	globals.selectedTab = newTab
+	// Repaint UI and switch
 	layoutTabs; drawTabs
+	switchToTab newTab
 end function
 OpenFile.confirmAndClose = function()
 	dlog = textUtil.Dialog.make("Save changes to " + self.tabTitle + "?",


### PR DESCRIPTION
This PR fixes some bugs in the logic when a tab is closed:

* Tab was being removed by object and not by index (`list.remove(i)` expects an index) - as a result the tab was not being removed at all
* Close button of removed tab was not being removed from the display
* There was no switching to another, still open tab
* After re-laying out the tabs (after one was closed) the positions of existing close-buttons were not being re-calculated
* A `yield` statement was needed in order for the `worldBounds` of the close-buttons to be properly calculated when adding new or removing tabs 