### PR TITLE
Make qa.assertEqual usa @-operator

### DIFF
--- a/sys/lib/dateTime.ms
+++ b/sys/lib/dateTime.ms
@@ -110,16 +110,14 @@ runUnitTests = function
 	else
 		print errorCount + " error" + "s" * (errorCount!=1) + " found."
 	end if
-end function
-
-
-if locals == globals then
-	runUnitTests
+	
 	// Normally, dateTime would not be run in the global space, so its
 	// special str and val methods would not hide the intrinsics... but
 	// since it was, let's remove those so as to not cause grief.
 	dt = {"str":@str, "val":@val}	// (access these as dt.str and dt.val, for testing)
 	globals.remove "str"
 	globals.remove "val"
-end if
-	
+end function
+
+
+if locals == globals then runUnitTests

--- a/sys/lib/dateTime.ms
+++ b/sys/lib/dateTime.ms
@@ -110,14 +110,16 @@ runUnitTests = function
 	else
 		print errorCount + " error" + "s" * (errorCount!=1) + " found."
 	end if
-	
+end function
+
+
+if locals == globals then
+	runUnitTests
 	// Normally, dateTime would not be run in the global space, so its
 	// special str and val methods would not hide the intrinsics... but
 	// since it was, let's remove those so as to not cause grief.
 	dt = {"str":@str, "val":@val}	// (access these as dt.str and dt.val, for testing)
 	globals.remove "str"
 	globals.remove "val"
-end function
-
-
-if locals == globals then runUnitTests
+end if
+	

--- a/sys/lib/qa.ms
+++ b/sys/lib/qa.ms
@@ -59,10 +59,10 @@ end function
 // assertEqual: abort if the first two parameters are not equal.
 // Additional descriptive note is optional.
 assertEqual = function(actual, expected, note)
-	if actual == expected then return
+	if @actual == @expected then return
 	msg = "Assert failed"
 	if note != null then msg = msg + " (" + note + ")"
-	msg = msg + ": expected `" + expected + "`, but got `" + actual + "`"
+	msg = msg + ": expected `" + @expected + "`, but got `" + @actual + "`"
 	abort msg
 end function
 
@@ -94,11 +94,11 @@ end function
 // assertType: abort if the first parameter is not of the specified type.
 // Additional descriptive note is optional.
 assertType = function(value, type, note)
-	if value isa type then return
+	if @value isa type then return
 	msg = "Assert failed"
 	if note != null then msg = msg + " (" + note + ")"
 	msg = msg + ": expected type " + namedMaps[type] + 
-	  ", but got a " + typeOf(value) + " (" + value + ")"
+	  ", but got a " + typeOf(@value) + " (" + @value + ")"
 	abort msg
 end function
 

--- a/sys/startup.ms
+++ b/sys/startup.ms
@@ -591,5 +591,22 @@ welcome = function
 	print
 end function
 
+_import = function(moduleName)
+	import moduleName
+	return locals[moduleName]
+end function
+
+runSysLibTests = function
+	moduleNames = ["dateTime", "grfon", "json", "listUtil", "mapUtil", "mathUtil", "qa", "stringUtil", "tsv"]
+	for moduleName in moduleNames
+		print "--- " + moduleName + " ---"
+		mod = _import(moduleName)
+		mod.runUnitTests
+		print "press enter>", ""
+		input
+	end for
+end function
+
 if _bootOpt("startupChime", true) then _startupChime
 if _bootOpt("welcome", true) then welcome else clear
+if env.cmdLineArgs.indexOf("--testSysLib") != null then runSysLibTests


### PR DESCRIPTION
Fix errors in situations like this:
```
i = 0
f = function ; outer.i += 1 ; return i ; end function
qa.assertEqual @f, @f
```