### PR TITLE
Use @-operator before key in map.get

### DIFF
--- a/sys/lib/mapUtil.ms
+++ b/sys/lib/mapUtil.ms
@@ -7,7 +7,7 @@
 map.get = function(key, defaultValue=null)
 	m = self
 	while m
-		if m.hasIndex(key) then return m[key]
+		if m.hasIndex(@key) then return m[@key]
 		if not m.hasIndex("__isa") then break
 		m = m.__isa
 	end while
@@ -119,12 +119,13 @@ runUnitTests = function
 		end if
 	end function
 
-	d = {"one":"ichi", "two":"ni", "three":"san", "four":"shi", "five":"go"}
+	d = {"one":"ichi", "two":"ni", "three":"san", "four":"shi", "five":"go", @print: "six"}
 
 	testing = "get"
 	assertEqual d.get("one", 1), "ichi"
 	assertEqual d.get("ten", 10), 10
 	assertEqual d.get("twenty"), null
+	assertEqual d.get(@print), "six"
 	
 	testing = "hasValue"
 	assertEqual d.hasValue("ni"), true


### PR DESCRIPTION
Fixing
```
]import "mapUtil"
]m = {}
]f = function ; return 42 ; end function
]m[@f] = "foo"
]m.get(@f, "bar")
bar
]
```