### PR TITLE
Fix mapUtil unit test

### DIFF
--- a/sys/lib/mapUtil.ms
+++ b/sys/lib/mapUtil.ms
@@ -127,6 +127,8 @@ runUnitTests = function
 	assertEqual d.get("twenty"), null
 	assertEqual d.get(@print), "six"
 	
+	d.remove @print
+	
 	testing = "hasValue"
 	assertEqual d.hasValue("ni"), true
 	assertEqual d.hasValue("foo"), false


### PR DESCRIPTION
The addition of `@print` key in a previous commit broke the unit test :blush: 
Fixing