### PR TITLE
Fix small typo in startup.ms

### DIFF
--- a/sys/startup.ms
+++ b/sys/startup.ms
@@ -608,7 +608,7 @@ runSysLibTests = function
 		print "--- " + moduleName + " ---"
 		mod = _importAndReturn(moduleName)
 		mod.runUnitTests
-		input "[Rress Return]"
+		input "[Press Return]"
 	end for
 end function
 


### PR DESCRIPTION
Fixes "[Rress Return]" to "[Press Return]"