### PR TITLE
fatbits now uses FileDialog to open files

### DIFF
--- a/sys/demo/fatbits.ms
+++ b/sys/demo/fatbits.ms
@@ -942,6 +942,7 @@ setupUI.draw = function
 			self.state = kDone
 		end if
 	else if self.state == kLoadFile then
+		key.clear
 		hit = self.dlog.show
 		if hit == self.dlog.okBtn then
 			self.path = self.dlog.selection

--- a/sys/demo/fatbits.ms
+++ b/sys/demo/fatbits.ms
@@ -905,6 +905,7 @@ setupUI.draw = function
 	gfx.fillRect 0, 0, 960, 640-26, text.backColor
 	spriteDisp.scrollX = 9999
 	self.buttons = []
+	self.dlog = textUtil.FileDialog.make
 	if self.state == kStart then
 		textUtil.printCenteredAt 34, 21, "Create or Load Image"
 		newBtn = new textUtil.DialogButton
@@ -941,18 +942,21 @@ setupUI.draw = function
 			self.state = kDone
 		end if
 	else if self.state == kLoadFile then
-		textUtil.printCenteredAt 34, 21, "Load Image"
-		textUtil.printAt 10, 18, "Current Directory: " + pwd
-		self.path = self.inputAt(10, 16, "Image file path: ")
-		if self.path[-4:] != ".png" then self.path = self.path + ".png"
-		self.img = file.loadImage(self.path)
-		if self.img == null then
-			textUtil.Dialog.make("Unable to Open File", "Invalid path:" + char(13) + self.path).show
+		hit = self.dlog.show
+		if hit == self.dlog.okBtn then
+			self.path = self.dlog.selection
+			self.img = file.loadImage(self.path)
+			if self.img == null then
+				textUtil.Dialog.make("Unable to Open File", "Invalid path:" + char(13) + self.path).show
+				self.state = kStart
+				self.draw
+			else
+				addTabForImage self.img, self.path
+				self.state = kDone
+			end if
+		else // "Cancel" button pressed
 			self.state = kStart
 			self.draw
-		else
-			addTabForImage self.img, self.path
-			self.state = kDone
 		end if
 	end if
 	self.drawButtons


### PR DESCRIPTION
Joe wrote on the MiniScript Discord:

> Suddenly realized this week that /sys/demo/fatbits should be using the file browser (from /sys/lib/textUtil) to open an image, rather than asking the user to manually type in a path.  This is probably a simple change, but I'm pretty swamped right now trying to catch up on things after my trip.  Anybody want to bang that out and submit a PR (or just send me the revised script)?

As per this request, I changed /sys/demo/fatbits.ms to use `FileDialog` from `textUtil`.

I tested three cases:

1. `Cancel` button is pressed. Nothing is done. :white_check_mark: 
2. `Select` button is pressed on a valid image. The image opens. :white_check_mark: 
3. `Select` button is pressed on an invalid image. The user is given the error message and nothing further is done. :white_check_mark: