### PR TITLE
Change return to continue in ensureImport function

### DIFF
--- a/sys/lib/importUtil.ms
+++ b/sys/lib/importUtil.ms
@@ -18,7 +18,7 @@
 globals.ensureImport = function(moduleName)
 	if moduleName isa string then moduleName = [moduleName]
 	for name in moduleName
-		if globals.hasIndex(name) then return
+		if globals.hasIndex(name) then continue
 		globals[name] = "PENDING"	// (module is being imported now)
 		import name
 		globals[name] = locals[name]


### PR DESCRIPTION
Fixed ensureImport.  When importing a list of modules, if one module had already been imported, ensureImport would return in the middle of the loop not importing the rest of the list.